### PR TITLE
Angiv 'flyt' og 'mv' i korrekt rækkefølge

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,4 @@ global effekt.
     git config --global alias.maerke tag
     git config --global alias.indkreds bisect
     git config --global alias.klon clone
-    git config --global alias.mv flyt
+    git config --global alias.flyt mv


### PR DESCRIPTION
Fastlæggelse 0a666f2b ("flyt (mv)") tilføjede aliaset "flyt", men der
var byttet om på alias og den underligende kommando.